### PR TITLE
Add HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,15 @@ Provide a RESTful API to query information about Amazon AWS AMIs.
 
 ## Prerequisites
 
-`ami-query` is written in Go. You need to have version 1.5.1 or higher
-installed. For Go installation instructions see https://golang.org/doc/install.
-
-Third party packages are
-[vendored](https://code.google.com/p/go-wiki/wiki/PackageManagementTools) using
-the Go 1.5 [vendor experiment](https://golang.org/s/go15vendor).
+`ami-query` is written in Go. You need to have version 1.8 or higher installed.
+For Go installation instructions see https://golang.org/doc/install.
 
 ## Installation
 
-To install `ami-query` export `GOPATH` and `GO15VENDOREXPERIMENT` then use
-`go get`.
+To install `ami-query` export `GOPATH` then use `go get`.
 
 ```shell
 $ export GOPATH=$HOME/go
-$ export GO15VENDOREXPERIMENT=1
 $ go get github.com/intuit/ami-query
 ```
 
@@ -104,6 +98,16 @@ The configuration is handled through the following environment variables.
 
   The file location to send HTTP log messages. Note that `ami-query` does not
   manage this file, it only writes to it. The default is to log to STDERR.
+
+* **SSL_CERTIFICATE_FILE**
+
+  The file location of the SSL certificate file. **SSL_KEY_FILE** also needs to
+  be specified in order to enable HTTPS support.
+
+* **SSL_KEY_FILE**
+
+  The file location of the SSL key file. **SSL_CERTIFICATE_FILE** also needs to
+  be specified in order to enable HTTPS support.
 
 #### Example Configuration
 

--- a/amicache/manager.go
+++ b/amicache/manager.go
@@ -23,15 +23,17 @@ import (
 // Supported regions
 var supportedRegions = []string{
 	"us-east-1",
+	"us-east-2",
 	"us-west-1",
 	"us-west-2",
 	"eu-west-1",
 	"eu-central-1",
 	"ap-northeast-1",
+	"ap-northeast-2",
 	"ap-southeast-1",
 	"ap-southeast-2",
+	"ap-south-1",
 	"sa-east-1",
-	"cn-north-1",
 }
 
 // Minimum time allowed between cache updates

--- a/config.go
+++ b/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	Manager    amicache.CacheManager
 	CacheTTL   time.Duration
 	RoleARN    string
+	SSLCert    string
+	SSLKey     string
 }
 
 // NewConfig returns a Config with settings pulled from the environment. See
@@ -72,6 +74,14 @@ func NewConfig() (*Config, error) {
 		cfg.Manager = amicache.NewMemcachedManager(servers...)
 	default:
 		cfg.Manager = amicache.NewInternalManager()
+	}
+
+	// SSL cert and key used for HTTPS
+	if sslCert := os.Getenv("SSL_CERTIFICATE_FILE"); sslCert != "" {
+		cfg.SSLCert = sslCert
+	}
+	if sslkey := os.Getenv("SSL_KEY_FILE"); sslkey != "" {
+		cfg.SSLKey = sslkey
 	}
 
 	return cfg, nil

--- a/resources/Makefile
+++ b/resources/Makefile
@@ -1,5 +1,5 @@
 NAME       = ami-query
-VERSION    = 1.0.0
+VERSION    = 1.1.0
 RPM_TOPDIR = "$(shell pwd)/rpmbuild"
 
 RPMBUILD_ARGS := \

--- a/resources/rhel/rc.ami-query
+++ b/resources/rhel/rc.ami-query
@@ -35,7 +35,7 @@ pidfile=/var/run/$prog.pid
 
 RUN_AS=""
 
-[ -n "$AMIQUERY_USER" ] && RUN_AS="--user=$AMIQUERY_USER"
+[ -n "${AMIQUERY_USER}" ] && RUN_AS="--user=$AMIQUERY_USER"
 [ -n "${AMIQUERY_OWNER_IDS}" ] && export AMIQUERY_OWNER_IDS="$AMIQUERY_OWNER_IDS"
 [ -n "${AMIQUERY_REGIONS}" ] && export AMIQUERY_REGIONS="$AMIQUERY_REGIONS"
 [ -n "${AMIQUERY_APP_LOGFILE}" ] && export AMIQUERY_APP_LOGFILE="$AMIQUERY_APP_LOGFILE"
@@ -46,6 +46,8 @@ RUN_AS=""
 [ -n "${AMIQUERY_MEMCACHED_SERVERS}" ] && export AMIQUERY_MEMCACHED_SERVERS="$AMIQUERY_MEMCACHED_SERVERS"
 [ -n "${AWS_ACCESS_KEY_ID}" ] && export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
 [ -n "${AWS_SECRET_ACCESS_KEY}" ] && export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+[ -n "${SSL_CERTIFICATE_FILE}" ] && export SSL_CERTIFICATE_FILE="$SSL_CERTIFICATE_FILE"
+[ -n "${SSL_KEY_FILE}" ] && export SSL_KEY_FILE="$SSL_KEY_FILE"
 [ -n "${http_proxy}" ] && export http_proxy="$http_proxy"
 [ -n "${https_proxy}" ] && export https_proxy="$https_proxy"
 [ -n "${no_proxy}" ] && export no_proxy="$no_proxy"

--- a/resources/rhel/settings
+++ b/resources/rhel/settings
@@ -84,6 +84,15 @@ AMIQUERY_OWNER_IDS=
 #AMIQUERY_HTTP_LOGFILE=/var/log/ami-query_http.log
 
 #
+# The SSL certificate to use if running HTTPS.
+#
+#SSL_CERTIFICATE_FILE=
+
+#
+# The SSL key to use if running HTTPS.
+#SSL_KEY_FILE=
+
+#
 # The following settings only apply when communicating to AWS through a proxy
 # server.
 #


### PR DESCRIPTION
Add HTTPS support to ami-query. This adds two new environment variables:
SSL_CERTIFICATE_FILE and SSL_KEY_FILE, which specify the locations of
the cert and key file respectively. If both env vars are defined,
ami-query will listen for TLS connections.

In addition, updated supported regions and added timeouts to the http.Client
to prevent AWS API calls from hanging indefinitely.

Addresses #2.

/cc @bw-intuit 